### PR TITLE
Fix typo and table coloring after apiRoute block

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -67,7 +67,7 @@ In this document a package for describing REST API is tested.
 
 \begin{apiRoute}{get}{/api/storage/}{get a list of all storage's}
 	\begin{routeParameter}
-		\noRouteParamter{no parameter}
+		\noRouteParameter{no parameter}
 	\end{routeParameter}
 	\begin{routeResponse}{application/json}
 		\begin{routeResponseItem}{200}{ok}
@@ -92,7 +92,7 @@ In this document a package for describing REST API is tested.
 
 \begin{apiRoute}{get}{/api/storage/}{}
 	\begin{routeParameter}
-		\noRouteParamter{no parameter}
+		\noRouteParameter{no parameter}
 	\end{routeParameter}
 	\begin{routeResponse}{application/json}
 		\noRouteResponse{no response}
@@ -103,7 +103,7 @@ In this document a package for describing REST API is tested.
 
 \begin{apiRoute}{post}{/api/storage/}{create a new storage}
 	\begin{routeParameter}
-		\noRouteParamter{no parameter}
+		\noRouteParameter{no parameter}
 	\end{routeParameter}
 	\begin{routeRequest}{application/json}
 		\begin{routeRequestBody}

--- a/rest-api.dtx
+++ b/rest-api.dtx
@@ -121,7 +121,7 @@
 \begin{lstlisting}[frame=single,breaklines=true]
 \begin{apiRoute}{get}{/api/storage/}{get a list of all storage's}
 	\begin{routeParameter}
-		\noRouteParamter{no parameter}
+		\noRouteParameter{no parameter}
 	\end{routeParameter}
 	\begin{routeResponse}{application/json}
 		\begin{routeResponseItem}{200}{ok}
@@ -155,7 +155,7 @@
 \begin{lstlisting}[frame=single,breaklines=true]
 \begin{apiRoute}{get}{/api/storage/}{}
 	\begin{routeParameter}
-		\noRouteParamter{no parameter}
+		\noRouteParameter{no parameter}
 	\end{routeParameter}
 	\begin{routeResponse}{application/json}
 		\noRouteResponse{no response}
@@ -173,7 +173,7 @@
 \begin{lstlisting}[frame=single,breaklines=true]
 \begin{apiRoute}{post}{/api/storage/}{create a new storage}
 	\begin{routeParameter}
-		\noRouteParamter{no parameter}
+		\noRouteParameter{no parameter}
 	\end{routeParameter}
 	\begin{routeRequest}{application/json}
 		\begin{routeRequestBody}
@@ -327,12 +327,12 @@
 % \DescribeEnv{routeParameter}
 %	Describe the path parameter.
 %	Contains a list of \textbackslash routeParamItem commands.
-%	If no paramters excists you can use the command \textbackslash noRouteParamter.
+%	If no paramters excists you can use the command \textbackslash noRouteParameter.
 %
 % \DescribeMacro{\routeParamItem}
 %	Describe a parameter with name and describtion.
 %
-% \DescribeMacro{\noRouteParamter}
+% \DescribeMacro{\noRouteParameter}
 %	Show a text e.g. 'no parameter'.
 %
 % \DescribeEnv{routeResponse}
@@ -884,7 +884,7 @@
 	{
 		\rowcolor{\methodLightColor} ##1 & ##2 \\
 	}
-	\newcommand{\noRouteParamter}[1]
+	\newcommand{\noRouteParameter}[1]
 	{
 		\small{\textit{##1}}
 	}

--- a/rest-api.dtx
+++ b/rest-api.dtx
@@ -751,6 +751,7 @@
 %    \begin{macrocode}
 \newenvironment{apiRoute}[3]
 {
+	\global\let\saved@CT@arc@\CT@arc@
 	\newcommand{\method}{#1}
 	\newcommand{\urlPath}{#2}
 	\newcommand{\routeDescription}{#3}
@@ -847,6 +848,7 @@
 {
 		\end{mdframed}
 	\endgroup
+	\global\let\CT@arc@\saved@CT@arc@
 }
 %    \end{macrocode}
 %


### PR DESCRIPTION
Fix #1 typo in \noRouteParamter
Fix #2 table coloring after apiRoute block 